### PR TITLE
Styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,8 @@ Notifcation bar plugin for Bootstrap + jQuery / Zepto
 <!-- Bootstrap JavaScript -->
 <script src="http://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 
-<!-- Finally the bootbar CSS and JS -->
+<!-- Finally the bootbar JS -->
 <script src="bootbar.js"></script>
-<link rel="stylesheet" href="bootbar.css">
 ```
 
 # Usage:
@@ -41,14 +40,15 @@ $.bootbar.info("This is a simple info bar. Click the &times; to close.");
 // Here are the defaults and the options available for configuration:
 
 var options = {
-        autoDismiss: false,      // Don't automatically dismiss the bar.
-        autoLinkClass: true,     // onDraw callback
-        barType: "info",         // info box
-        dismissTimeout: 3000,    // 3 Seconds
-        dismissEffect: "slide",  // Slide away: (slide, fade)
-        dismissSpeed: "fast",    // Dismiss speed: (slow, fast)
-        onDraw: null,            // onDraw callback
-        onDismiss: null          // onDismiss callback
+        alertClass: "bootbar-alert",    // Default class of the alert is "bootbar-alert"
+        autoDismiss: false,             // Don't automatically dismiss the bar.
+        autoLinkClass: true,            // onDraw callback
+        barType: alertTypes[0],         // info
+        dismissTimeout: 3000,           // 3 Seconds
+        dismissEffect: "slide",         // Slide away: (slide, fade)
+        dismissSpeed: "fast",           // Dismiss speed: (slow, fast)
+        onDraw: null,                   // onDraw callback
+        onDismiss: null                 // onDismiss callback
 };
 
 // Feel free to change any of them to suit your needs.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ bootbar
 
 Notifcation bar plugin for Bootstrap + jQuery / Zepto
 
-Installation:
+# Installation:
 
 ```html
 <!-- We need jquery 1.8+ -->
@@ -22,7 +22,7 @@ Installation:
 <link rel="stylesheet" href="bootbar.css">
 ```
 
-Usage:
+# Usage:
 
 ```javascript
 // Raise a simple info bar:
@@ -35,7 +35,7 @@ $.bootbar.info("This is a simple info bar. Click the &times; to close.");
 // $.bootbar.success
 ```
 
-Advanced Usage:
+# Advanced Usage:
 
 ```javascript
 // Here are the defaults and the options available for configuration:

--- a/bootbar.css
+++ b/bootbar.css
@@ -1,6 +1,6 @@
-.alert-messages {
+.bootbar-alert {
     position: fixed;
-    top: 0px;
+    top: 0;
     left: 0;
     right: 0;
     z-index: 10000000;

--- a/bootbar.js
+++ b/bootbar.js
@@ -26,23 +26,37 @@
                 var alertTypes = ["info", "warning", "danger", "success"];
 
                 var defaults = {
-                        autoDismiss: false,      // Don't automatically dismiss the bar.
-                        autoLinkClass: true,     // onDraw callback
-                        barType: alertTypes[0],  // info
-                        dismissTimeout: 3000,    // 3 Seconds
-                        dismissEffect: "slide",  // Slide away: (slide, fade)
-                        dismissSpeed: "fast",    // Dismiss speed: (slow, fast)
-                        onDraw: null,            // onDraw callback
-                        onDismiss: null          // onDismiss callback
+                        alertClass: "bootbar-alert",    // Default class of the alert is "bootbar-alert"
+                        autoDismiss: false,             // Don't automatically dismiss the bar.
+                        autoLinkClass: true,            // onDraw callback
+                        barType: alertTypes[0],         // info
+                        dismissTimeout: 3000,           // 3 Seconds
+                        dismissEffect: "slide",         // Slide away: (slide, fade)
+                        dismissSpeed: "fast",           // Dismiss speed: (slow, fast)
+                        onDraw: null,                   // onDraw callback
+                        onDismiss: null                 // onDismiss callback
                 };
 
                 var settings = $.extend({}, defaults, options || {});
 
-                var template = $("<div class=\"alert alert-dismissable alert-messages\">" +
+                var template = $("<div>" +
                                     "<button type=\"button\" class=\"close\" aria-hidden=\"true\">&times;</button>" +
                                 "</div>");
 
+                var alertCss = {
+                    position  : "fixed",
+                    left: 0,
+                    top: 0,
+                    right: 0,
+                    "z-index": 10000
+                };
+
+                template.css(alertCss);
+
+                // Add the class from options (if provided)
+                template.addClass("alert alert-dismissable");
                 template.addClass("alert-" + settings.barType);
+                template.addClass(settings.alertClass);
                 template.append(message);
 
                 if (settings.autoLinkClass) {


### PR DESCRIPTION
Small improvements to make styling more flexible:
- Change the default class from alert-message (confusing) to bootbar alert
- Make the class of the alert configurable via the alertClass option
- Move the styling out of the html code
- Remove the CSS and use inline styling via jQuery instead 

Reasons for removing CSS:
- One less dependency
- Common to almost all notification plugins
